### PR TITLE
Play pending audio frames in `fenster_audio.h` instead of stopping playback immediately

### DIFF
--- a/fenster_audio.h
+++ b/fenster_audio.h
@@ -124,6 +124,9 @@ FENSTER_API void fenster_audio_write(struct fenster_audio *fa, float *buf,
   }
 }
 FENSTER_API void fenster_audio_close(struct fenster_audio *fa) {
+  for (int i = 0; i < 2; i++)
+    while (!(fa->hdr[i].dwFlags & WHDR_DONE))
+      Sleep(10);
   waveOutClose(fa->wo);
 }
 #elif defined(__linux__)


### PR DESCRIPTION
Cherry-pick of zserge/fenster#42:
> This will resolve audio cutting off after a program using `fenster_audio.h` finishes it's execution - a very simple fix that will greatly simplify the usage of the `fenster_audio.h` library.
> 
> I implemented this only for the Linux and Win32 version in this PR, because as far as I know the macOS version already worked this way, since `inImmediate` is set to `false` when calling `AudioQueueStop(AudioQueueRef inAQ, Boolean inImmediate)` at https://github.com/jonasgeiler/fenster/blob/1393ff82958532e3f8c5dfdf5b131c065cb513e7/fenster_audio.h#L78